### PR TITLE
Remove the lifetime in `EcdsaXi2023`.

### DIFF
--- a/src/optical_barcode_credential/compression/encoding.rs
+++ b/src/optical_barcode_credential/compression/encoding.rs
@@ -14,8 +14,8 @@ fn encode_options() -> EncodeOptions {
     }
 }
 
-pub async fn encode<'a, T>(
-    vc: &DataIntegrity<OpticalBarcodeCredential<T>, EcdsaXi2023<&'a [u8]>>,
+pub async fn encode<T>(
+    vc: &DataIntegrity<OpticalBarcodeCredential<T>, EcdsaXi2023>,
 ) -> cbor_ld::CborValue
 where
     T: OpticalBarcodeCredentialSubject,
@@ -26,8 +26,8 @@ where
         .unwrap()
 }
 
-pub async fn encode_to_bytes<'a, T>(
-    vc: &DataIntegrity<OpticalBarcodeCredential<T>, EcdsaXi2023<&'a [u8]>>,
+pub async fn encode_to_bytes<T>(
+    vc: &DataIntegrity<OpticalBarcodeCredential<T>, EcdsaXi2023>,
 ) -> Vec<u8>
 where
     T: OpticalBarcodeCredentialSubject,

--- a/src/optical_barcode_credential/mod.rs
+++ b/src/optical_barcode_credential/mod.rs
@@ -53,29 +53,3 @@ pub unsafe trait OpticalBarcodeCredentialSubject: Serialize + DeserializeOwned {
 
     fn create_optical_data(&self, xi: &Self::ExtraInformation) -> [u8; 32];
 }
-
-pub fn change_xi_lifetime<'a, 'b, T: OpticalBarcodeCredentialSubject>(
-    vc: DataIntegrity<OpticalBarcodeCredential<T>, EcdsaXi2023<&'a [u8]>>,
-) -> DataIntegrity<OpticalBarcodeCredential<T>, EcdsaXi2023<&'b [u8]>> {
-    unsafe {
-        // SAFETY: the lifetime in `EcdsaXi2023` is completely unused,
-        //         it does not refer any data stored in `vc`.
-        std::mem::transmute::<
-            DataIntegrity<OpticalBarcodeCredential<T>, EcdsaXi2023<&'a [u8]>>,
-            DataIntegrity<OpticalBarcodeCredential<T>, EcdsaXi2023<&'b [u8]>>,
-        >(vc)
-    }
-}
-
-pub fn change_xi_lifetime_ref<'r, 'a, 'b, T: OpticalBarcodeCredentialSubject>(
-    vc: &'r DataIntegrity<OpticalBarcodeCredential<T>, EcdsaXi2023<&'a [u8]>>,
-) -> &'r DataIntegrity<OpticalBarcodeCredential<T>, EcdsaXi2023<&'b [u8]>> {
-    unsafe {
-        // SAFETY: the lifetime in `EcdsaXi2023` is completely unused,
-        //         it does not refer any data stored in `vc`.
-        std::mem::transmute::<
-            &'r DataIntegrity<OpticalBarcodeCredential<T>, EcdsaXi2023<&'a [u8]>>,
-            &'r DataIntegrity<OpticalBarcodeCredential<T>, EcdsaXi2023<&'b [u8]>>,
-        >(vc)
-    }
-}


### PR DESCRIPTION
The extra data is now passed by copy, instead of by reference. This is not ideal from a memory performance point of view, but that's the only way to get around the compler issue rust-lang/rust#100013
Fixes #1